### PR TITLE
(GH-1) Fix action bar scroll bar being forced

### DIFF
--- a/src/pell.scss
+++ b/src/pell.scss
@@ -32,7 +32,7 @@ $pell-button-width: 30px !default;
   border-top-right-radius: $pell-border-radius;
   height: $pell-actionbar-height;
   left: 0;
-  overflow-x: scroll;
+  overflow-x: auto;
   overflow-y: hidden;
   position: absolute;
   top: 0;


### PR DESCRIPTION
Currently the scroll bar is being forced to always appear. I assume the intent was to have it show up on overflow. Though you might still have height issues on collapse.