### PR TITLE
Removed  `overflow-x: scroll` from pell-actionbar

### DIFF
--- a/src/pell.scss
+++ b/src/pell.scss
@@ -32,7 +32,6 @@ $pell-button-width: 30px !default;
   border-top-right-radius: $pell-border-radius;
   height: $pell-actionbar-height;
   left: 0;
-  overflow-x: scroll;
   overflow-y: hidden;
   position: absolute;
   top: 0;


### PR DESCRIPTION
Looking at the demo at https://jaredreich.com/pell I saw a scrollbar blocking most of the action bar (Chrome 59.0.3071.115 64-bit)
So I removed ` `overflow-x: scroll` from pell-actionbar to fix it.