### PR TITLE
Make it possible to give pell a HTMLElement directly

### DIFF
--- a/src/pell.js
+++ b/src/pell.js
@@ -118,7 +118,9 @@ export const init = settings => {
 
   settings.classes = { ...defaultSettings.classes, ...settings.classes }
 
-  const root = document.getElementById(settings.root)
+  const root = settings.root instanceof window.HTMLElement
+    ? settings.root
+    : document.getElementById(settings.root)
   const editor = document.createElement('div')
   editor.contentEditable = true
   editor.className = settings.classes.editor


### PR DESCRIPTION
Currently pell only accepts `root` as a string. My PR allows pell to accept a HTMLElement as well.

Tested in all browser listed in the read me