### PR TITLE
Add a link to the live demo on GIF image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Live demo: [https://jaredreich.com/pell](https://jaredreich.com/pell)
 
-![Alt text](/demo.gif?raw=true "Demo")
+[![Live demo](/demo.gif?raw=true "Demo")](https://jaredreich.com/pell)
 
 ## Comparisons
 


### PR DESCRIPTION
I clicked into the GIF as I thought it would link to a demo, but it wasn't. So here it is 😄 