### PR TITLE
Declare button-attribute 'type'

### DIFF
--- a/src/pell.js
+++ b/src/pell.js
@@ -118,6 +118,7 @@ export const init = settings => {
     button.className = settings.classes.button
     button.innerHTML = action.icon
     button.title = action.title
+    button.type = 'button'
     button.onclick = action.result
     actionbar.appendChild(button)
   })


### PR DESCRIPTION
I added the button-attribute 'type="button"' to prevent browser-refresh in several cases when clicking on the editor-buttons.