### PR TITLE
Set content as scope for actions

### DIFF
--- a/src/pell.js
+++ b/src/pell.js
@@ -140,7 +140,7 @@ export const init = settings => {
     button.innerHTML = action.icon
     button.title = action.title
     button.setAttribute('type', 'button')
-    button.onclick = () => action.result() && content.focus()
+    button.onclick = () => action.result.call(content) && content.focus()
 
     if (action.state) {
       const handler = () => button.classList[action.state() ? 'add' : 'remove'](classes.selected)


### PR DESCRIPTION
...to allow for actions beyond document.execCommand(), especially for multiple instances.