### PR TITLE
allow tab key input (fixes jaredreich/pell#66, satisfies WCAG 2.1.2)

### DIFF
--- a/src/pell.js
+++ b/src/pell.js
@@ -126,9 +126,7 @@ export const init = settings => {
     settings.onChange(content.innerHTML)
   }
   content.onkeydown = event => {
-    if (event.key === 'Tab') {
-      event.preventDefault()
-    } else if (event.key === 'Enter' && queryCommandValue(formatBlock) === 'blockquote') {
+    if (event.key === 'Enter' && queryCommandValue(formatBlock) === 'blockquote') {
       setTimeout(() => exec(formatBlock, `<${defaultParagraphSeparator}>`), 0)
     }
   }


### PR DESCRIPTION
Preventing <kbd>Tab</kbd> key input without providing an alternative (and advising the user of that alternative) [violates WCAG 2.1.2 “No Keyboard Trap”](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html).  That breaks <kbd>Tab</kbd>-based focus navigation, which breaks pell for many users.

This PR re-enables the default behavior for the <kbd>Tab</kbd> key, fixing jaredreich/pell#66 and eliminating the WCAG violation.

If an application developer has a more relevant behavior for the <kbd>Tab</kbd> key, they can:
[ ] implement their alternative behavior for <kbd>Tab</kbd>
[ ] prevent the default behavior of <kbd>Tab</kbd>
[ ] implement an alternative keyboard input for escaping the editor
[ ] advise users about their alternative for escaping the editor