### PR TITLE
Remove constructor call

### DIFF
--- a/examples/react.md
+++ b/examples/react.md
@@ -8,11 +8,7 @@ import 'pell/dist/pell.css'
 
 class App extends Component {
   editor = null
-
-  constructor (props) {
-    super(props)
-    this.state = { html: null }
-  }
+  state = { html: null }
 
   componentDidMount () {
     this.editor = init({


### PR DESCRIPTION
I think having the constructor call in the example is not needed and it adds just noise to the example. Initialising the class property directly is most clear and succinct.