### PR TITLE
Makes Pell work in Microsoft Edge Classic

### DIFF
--- a/src/pell.js
+++ b/src/pell.js
@@ -103,13 +103,13 @@ export const init = settings => {
     ? (
       settings.actions.map(action => {
         if (typeof action === 'string') return defaultActions[action]
-        else if (defaultActions[action.name]) return { ...defaultActions[action.name], ...action }
+        else if (defaultActions[action.name]) return Object.assign({}, defaultActions[action.name], action)
         return action
       })
     )
     : Object.keys(defaultActions).map(action => defaultActions[action])
 
-  const classes = { ...defaultClasses, ...settings.classes }
+  const classes = Object.assign({}, defaultClasses, settings.classes)
 
   const defaultParagraphSeparator = settings[defaultParagraphSeparatorString] || 'div'
 


### PR DESCRIPTION
I realise this project is largely dormant but I figure it's useful for people who still use pell, since it is **still** the smallest, lightest rich editor available.

Using object rest destructuring requires pell to be pushed through babel for transpilation to older JS.

Switching to `Object.assign` means that it will work in Edge Classic without transpilation.

I don't use Babel on my sites any more because I stopped supporting IE11, so it's important that all libraries can run on Edge Classic without transpilation.